### PR TITLE
Potential fix for code scanning alert no. 1: Use of insecure SSL/TLS version

### DIFF
--- a/tgmi/toolbox/client.py
+++ b/tgmi/toolbox/client.py
@@ -12,6 +12,7 @@ import typing
 import urllib.parse
 
 context = ssl.create_default_context()
+context.minimum_version = ssl.TLSVersion.TLSv1_2
 context.check_hostname = False
 context.verify_mode = ssl.CERT_NONE
 context.load_cert_chain("../certs/client.crt","../certs/client.key")


### PR DESCRIPTION
Potential fix for [https://github.com/h3r0cybersec/tiny-gemini/security/code-scanning/1](https://github.com/h3r0cybersec/tiny-gemini/security/code-scanning/1)

To fix this safely without changing intended functionality, keep using `ssl.create_default_context()` but explicitly require TLS 1.2+ on the created context. The best single change is to set:

- `context.minimum_version = ssl.TLSVersion.TLSv1_2` (preferred on modern Python)

This should be added immediately after context creation in `tgmi/toolbox/client.py` so every socket wrapped by that global context inherits the restriction. This addresses both reported variants (TLSv1 and TLSv1_1 allowed) in one place.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
